### PR TITLE
Add --png cli option to export single frame stickers

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ArgumentParser } from 'argparse';
-import { toGifFromFile } from './index.js';
+import { toGifFromFile, toPngFromFile } from './index.js';
 import { createBrowser } from './utils.js';
 
 const convertFiles = async function (filePaths, browser, options) {
@@ -9,7 +9,11 @@ const convertFiles = async function (filePaths, browser, options) {
     console.log(`Converting ${filePath}...`);
 
     try {
-      await toGifFromFile(filePath, `${filePath}.gif`, options);
+      if(options.isPng) {
+        await toPngFromFile(filePath, `${filePath}.png`, options);
+      } else {
+        await toGifFromFile(filePath, `${filePath}.gif`, options);
+      }
     } catch (e) {
       console.error(e);
     }
@@ -20,6 +24,7 @@ const main = async function () {
   const parser = new ArgumentParser({
     description: 'Animated stickers for Telegram (*.tgs) to animated GIFs converter',
   });
+  parser.add_argument('--png', {help: 'Output as PNG instead of GIF for single frame stickers or save all frames as png', action: 'store_true'});
   parser.add_argument('--height', {help: 'Output image height. Default: auto', type: Number});
   parser.add_argument('--width', {help: 'Output image width. Default: auto', type: Number});
   parser.add_argument('--fps', {help: 'Output frame rate. Default: auto', type: Number});
@@ -41,7 +46,7 @@ const main = async function () {
   }
 
   const browser = await createBrowser();
-  await convertFiles(paths, browser, { width: args.width, height: args.height, fps: args.fps });
+  await convertFiles(paths, browser, { isPng: args.png, width: args.width, height: args.height, fps: args.fps });
   await browser.close();
 };
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import zlib from 'zlib';
 import os from 'os';
 import render from './render.js';
 import { createBrowser, removeDirectory, saveScreenshots, streamToString } from './utils.js';
+import path from 'path';
 
 const isWindows = ['win32', 'win64'].includes(os.platform());
 
@@ -58,6 +59,8 @@ export const toGif = fromStream(async function (animationData, outputPath, optio
   options.fps = options.fps || Math.min(animationData.fr, 50); // most viewers do not support gifs with FPS > 50
 
   const { dir, files, pattern } = await saveScreenshots(await render(options.browser, animationData, options));
+  // console.log({ dir, files, pattern });
+  // exit(0);
 
   try {
     await execa(
@@ -77,7 +80,31 @@ export const toGif = fromStream(async function (animationData, outputPath, optio
     await removeDirectory(dir);
   }
 });
+
+export const toPng = fromStream(async function (tgsData, outputPath, options = {}) {
+  options.quality = options.quality || 80;
+  options.fps = options.fps || Math.min(tgsData.fr, 50); // most viewers do not support gifs with FPS > 50
+
+  const { dir, files, pattern } = await saveScreenshots(await render(options.browser, tgsData, options));
+
+  try {
+    for (let i = 0; i < files.length; i++) {
+      const imagePath = outputPath.replace('.png', `-${i}.png`);
+      console.log(`Saving: ${imagePath}`);
+      const file = files[i];
+      // const destination = outputPath;
+      fs.copyFileSync(file, imagePath);
+      fs.unlinkSync(file);
+    }
+  } catch (e) {
+    throw e;
+  } finally {
+    await removeDirectory(dir);
+  }
+});
+
 export const toGifFromFile = fromFile(toGif);
+export const toPngFromFile = fromFile(toPng);
 
 // for capability with previous version
 export const convertFile = async function (inputPath, options = {}) {

--- a/utils.js
+++ b/utils.js
@@ -80,7 +80,7 @@ export const pad = function (num, size) {
 };
 
 export const removeDirectory = function (directoryPath) {
-    return new Promise((resolve, reject) => fs.rmdir(directoryPath, { recursive: true }, function (err, data) {
+    return new Promise((resolve, reject) => fs.rm(directoryPath, { recursive: true }, function (err, data) {
         if (err) {
             reject(err);
         } else {


### PR DESCRIPTION
## What?
Added support for single-frame stickers, designed to be exported as PNG files.

## Why?
I realized I needed stickers that are simple, single-frame PNG images. However, this repository only supported exporting as GIFs. To address this, I added PNG export support. :)
Additionally, if the `--png` flag is used with multi-framed `.tgs` files, all frames will be saved as PNG files.

## Screenshots
![Screenshot From 2025-01-12 00-26-05](https://github.com/user-attachments/assets/8ca18cd5-7270-4a44-9f4d-f801574dadd5)
![Screenshot From 2025-01-12 00-26-12](https://github.com/user-attachments/assets/de1d5bd9-9d28-47c7-813d-97b89a947180)
